### PR TITLE
[FEATURE] Added quick remote environment mounting tools.

### DIFF
--- a/.bash_xp
+++ b/.bash_xp
@@ -1,30 +1,34 @@
+XP_TOOLS_DIR="~/tools/Magento-2-Bash-Localhost-Installation-Script"
+
 function create_website() {
-    bash ~/tools/Magento-2-Bash-Localhost-Installation-Script/install.sh $1 $2 $3 $4
+    bash "$XP_TOOLS_DIR/install.sh" $1 $2 $3 $4
 }
 
 function create_pr_website() {
-    bash ~/tools/Magento-2-Bash-Localhost-Installation-Script/install_pr.sh $1 $2 $3 $4
+    bash "$XP_TOOLS_DIR/install_pr.sh" $1 $2 $3 $4
 }
 
 function add_module() {
-    bash ~/tools/Magento-2-Bash-Localhost-Installation-Script/add_module.sh $1 $2 $3
+    bash "$XP_TOOLS_DIR/add_module.sh" $1 $2 $3
 }
 
 function update_modules() {
-    bash ~/tools/Magento-2-Bash-Localhost-Installation-Script/update_modules.sh
+    bash "$XP_TOOLS_DIR/update_modules.sh"
 }
 
 function code_quality() {
-    bash ~/tools/Magento-2-Bash-Localhost-Installation-Script/code_quality.sh $1 $2 $3
+    bash "$XP_TOOLS_DIR/code_quality.sh" $1 $2 $3
 }
 
 function import_website() {
-    bash ~/tools/Magento-2-Bash-Localhost-Installation-Script/import.sh $1
+    bash "$XP_TOOLS_DIR/import.sh" $1
 }
 
 function update_website() {
-    bash ~/tools/Magento-2-Bash-Localhost-Installation-Script/update.sh $1
+    bash "$XP_TOOLS_DIR/update.sh" $1
 }
+
+source "$XP_TOOLS_DIR/environment_tools.sh"
 
 _site () 
 { 
@@ -89,7 +93,10 @@ alias cld='composer_lib_development'
 # Update Developer Programs Linux
 alias update_postman='sudo rm -rf /opt/Postman/; wget https://dl.pstmn.io/download/latest/linux64 -O postman.tar.gz; sudo tar -xzf postman.tar.gz -C /opt; rm postman.tar.gz'
 
-
+# Environment tools
+alias emnt=mount_site
+alias eumnt=umount_site
+alias edbg=debug_site
 
 # Custom prompt
 function parse_git_branch() { # Git Branch

--- a/config.sample.sh
+++ b/config.sample.sh
@@ -39,3 +39,7 @@ secure="false"
 CUSTOM_EE="example/magento-project-enterprise-edition"
 CUSTOM_CE="example/magento-project-community-edition"
 CUSTOM_REPO="https://repo.example.com"
+
+EMNT_DEFAULT_SITE_MOUNT_DIR='~/domains'
+EMNT_DEFAULT_SITE_REMOTE_LOCATION_FORMAT='~/domains/$SITE_DOMAIN.$SITE_ENV_HOST'
+EMNT_DEFAULT_SITE_LOCAL_LOCATION_FORMAT='$SITE_DOMAIN'

--- a/environment_tools.sh
+++ b/environment_tools.sh
@@ -1,0 +1,91 @@
+#!/bin/bash 
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+CONFIGPATH=$SCRIPTPATH/config.sh
+if [ -e $CONFIGPATH ]
+then
+    . $CONFIGPATH
+else
+    . $SCRIPTPATH/config.sample.sh
+fi
+
+EMNT_DEFAULT_SITE_CONFIG="$SCRIPTPATH/site_domain_aliases.txt"
+
+get_site_config_part() {
+	echo $(echo "$1" | cut -d$'\t' -f$2 ||)
+}
+
+get_site_config() {
+	CONFIG_FILE=$1
+	QUERY=$2
+	DEFAULT_ENV=$3
+
+	# Read configuration
+	CONFIG_LINE="$(grep -w "^$QUERY" "$CONFIG_FILE")"
+	
+	# Clear current loaded config
+	export SITE_DOMAIN=""
+	export SITE_ENV=""
+	export SITE_EXTRA=""
+	
+	SITE_DOMAIN="$(get_site_config_part "$CONFIG_LINE" 2)"
+	SITE_ENV="$(get_site_config_part "$CONFIG_LINE" 3)"
+	SITE_EXTRA="$(get_site_config_part "$CONFIG_LINE" 4)"
+
+	# Export current site info
+	export SITE_DOMAIN="${SITE_DOMAIN:-$QUERY}"
+	export SITE_ENV="${DEFAULT_ENV:-$SITE_ENV}"
+	export SITE_EXTRA="$SITE_EXTRA"
+}
+
+get_env_ssh_config() {
+	SITE_ENV=$1
+	export SITE_ENV_HOST="$(grep $SITE_ENV ~/.ssh/config -A 3 | grep '^.*HostName' | sed 's/HostName//' | tr -cd '[[:alnum:]]._-' | xargs)"
+}
+
+# Mount a remote website
+# mount_site alias/domain [ssh_alias] [mounting_dir]
+mount_site() {
+	# Get site config
+	get_site_config $EMNT_DEFAULT_SITE_CONFIG $1 $2
+
+	# Check site vars
+	if [ -z "$SITE_ENV" ]; then
+		echo "Could not find configuration for \"$SITE_DOMAIN\". Please check your config: $EMNT_DEFAULT_SITE_CONFIG."
+		return
+	fi
+
+	# If provided use given mount directory. Otherwise use default mount dir + domain name
+	MNT_DIR="$3"
+	if [ -z "$MNT_DIR" ]; then
+		MNT_DIR="$SITE_DOMAIN"
+	fi
+
+	get_env_ssh_config "$SITE_ENV"
+
+	SITE_REMOTE_LOCATION="$(echo "$EMNT_DEFAULT_SITE_REMOTE_LOCATION_FORMAT" | envsubst)"
+        if [ -z "$3" ]; then
+                SITE_LOCAL_LOCATION="$EMNT_DEFAULT_SITE_MOUNT_DIR/$(echo "$EMNT_DEFAULT_SITE_LOCAL_LOCATION_FORMAT" | envsubst)"
+	else
+		SITE_LOCAL_LOCATION=$3
+        fi
+
+	echo "Mounting: $SITE_DOMAIN on ENV: $SITE_ENV. $SITE_EXTRA"
+	echo "From $SITE_REMOTE_LOCATION to $SITE_LOCAL_LOCATION"
+
+	mkdir -p $SITE_LOCAL_LOCATION
+	fusermount3 -u $SITE_LOCAL_LOCATION
+	sshfs -C $SITE_ENV:$SITE_REMOTE_LOCATION $SITE_LOCAL_LOCATION
+}
+
+umount_site() {
+	get_site_config $EMNT_DEFAULT_SITE_CONFIG $1
+	SITE_LOCAL_LOCATION="$EMNT_DEFAULT_SITE_MOUNT_DIR/$(echo "$EMNT_DEFAULT_SITE_LOCAL_LOCATION_FORMAT" | envsubst)"
+	fusermount -u $SITE_LOCAL_LOCATION
+}
+
+debug_site() {
+    get_site_config $EMNT_DEFAULT_SITE_CONFIG $1
+	ssh -R 9000:localhost:9000 "${SITE_ENV:-$1}" -v
+}
+

--- a/site_domain_aliases.txt
+++ b/site_domain_aliases.txt
@@ -1,0 +1,1 @@
+example	example.com	example	Visit example.com


### PR DESCRIPTION
# Setup 
1. Change config variables `EMNT_DEFAULT_SITE_MOUNT_DIR` and `EMNT_DEFAULT_SITE_REMOTE_LOCATION_FORMAT` to your local and remote configuration.

2. Add your environmentsto `site_domain_alises.txt`. 
First segment: your specified alias [example]
Second segment: remote website domain [example.com]
Third segment: alias in ssh config [example_env]
Fourth segment: Anything

# Usage
`emnt example`
`emnt example example_env`
`emnt example example_env ~/home/domains/custom_folder`

`edbg example_env`
`edbg example`

