### PR TITLE
Nfs

### DIFF
--- a/composer_lib_development
+++ b/composer_lib_development
@@ -19,7 +19,7 @@ Available commands:
         link          Symlink lib folder to composer
         unlink        Remove symlink from composer and run composer install
         status        Show GIT status for changed packages
-        versions      Show latest version 
+        versions      Show latest version
         no_versions   Show packages that has commits with no version
 
 composer_development.json:
@@ -123,6 +123,7 @@ composer_development.json:
 
                 print('\nRun Composer install\n')
                 self.run_command(['composer', 'install'])
+                self.run_command(['rm', 'var/.regenerate']
 
         def status(self):
                 for name, lib_path in self.get_lib_packages():
@@ -137,12 +138,12 @@ composer_development.json:
 
         def versions(self):
                 for name, lib_path in self.get_lib_packages():
-                        version = self.run_command(['git', '-C', lib_path, 'describe', '--abbrev=0', '--tags']).strip() 
+                        version = self.run_command(['git', '-C', lib_path, 'describe', '--abbrev=0', '--tags']).strip()
                         print("{}: {}".format(name, version))
 
         def no_versions(self):
                 for name, lib_path in self.get_lib_packages():
-                        tags = self.run_command(['git', '-C', lib_path, 'tag', '--contains', 'HEAD']).strip() 
+                        tags = self.run_command(['git', '-C', lib_path, 'tag', '--contains', 'HEAD']).strip()
                         if not tags:
                                 print(name)
 

--- a/config.sample.sh
+++ b/config.sample.sh
@@ -48,3 +48,6 @@ EMNT_DEFAULT_SITE_LOCAL_LOCATION_FORMAT='$SITE_DOMAIN'
 
 ## name of your bitbucket vendor git@bitbucker.org:[VENDOR]/[MODULE]
 GIT_REPO_VENDOR='example'
+
+nfs="true"
+cache="redis"

--- a/git_import.sh
+++ b/git_import.sh
@@ -119,7 +119,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis"]; then
+  if [ "$cache" = "redis" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0

--- a/git_import.sh
+++ b/git_import.sh
@@ -65,12 +65,12 @@ if [ "$VERSION" = "m2" ]; then
 	cp $SCRIPTPATH/Helper/Placeholder/env.php $DIRECTORY/app/etc
 	composer install -d$DIRECTORY
 	rm $DIRECTORY/var/.regenerate
-	php $SCRIPTPATH/Helper/updateEnv.php -f$DIRECTORY -d$MYSQL_DATABASE_NAME -u$MYSQL_USER -p$MYSQL_PASSWORD
+	$PHP $SCRIPTPATH/Helper/updateEnv.php -f$DIRECTORY -d$MYSQL_DATABASE_NAME -u$MYSQL_USER -p$MYSQL_PASSWORD
 	$MAGERUN_COMMAND --root-dir=$DIRECTORY module:enable --all
 else
 	## Create new local.xml
 	cp $SCRIPTPATH/Helper/Placeholder/local.xml $DIRECTORY/app/etc/local.xml
-	php $SCRIPTPATH/Helper/updateLocal.php -f$DIRECTORY -d$MYSQL_DATABASE_NAME -u$MYSQL_USER -p$MYSQL_PASSWORD
+	$PHP $SCRIPTPATH/Helper/updateLocal.php -f$DIRECTORY -d$MYSQL_DATABASE_NAME -u$MYSQL_USER -p$MYSQL_PASSWORD
 fi
 
 ## Set correct base urls
@@ -80,13 +80,13 @@ do
 done
 
 ## Developer Settings
-php $DIRECTORY/bin/magento deploy:mode:set developer
+$PHP $DIRECTORY/bin/magento deploy:mode:set developer
 $PHP $DIRECTORY/bin/magento cache:enable
-php $DIRECTORY/bin/magento cache:disable layout block_html collections full_page
+$PHP $DIRECTORY/bin/magento cache:disable layout block_html collections full_page
 
 ### Generated PhpStorm XML Schema Validation
 mkdir -p $DIRECTORY/.idea
-php $DIRECTORY/bin/magento dev:urn-catalog:generate $DIRECTORY/.idea/misc.xml
+$PHP $DIRECTORY/bin/magento dev:urn-catalog:generate $DIRECTORY/.idea/misc.xml
 
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'admin/security/session_lifetime', '31536000') ON DUPLICATE KEY UPDATE value='31536000';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'web/cookie/cookie_lifetime', '31536000') ON DUPLICATE KEY UPDATE value='31536000';"

--- a/git_import.sh
+++ b/git_import.sh
@@ -64,6 +64,7 @@ if [ "$VERSION" = "m2" ]; then
 	mkdir -p $DIRECTORY/app/etc
 	cp $SCRIPTPATH/Helper/Placeholder/env.php $DIRECTORY/app/etc
 	composer install -d$DIRECTORY
+	rm $DIRECTORY/var/.regenerate
 	php $SCRIPTPATH/Helper/updateEnv.php -f$DIRECTORY -d$MYSQL_DATABASE_NAME -u$MYSQL_USER -p$MYSQL_PASSWORD
 	$MAGERUN_COMMAND --root-dir=$DIRECTORY module:enable --all
 else
@@ -80,6 +81,7 @@ done
 
 ## Developer Settings
 php $DIRECTORY/bin/magento deploy:mode:set developer
+$PHP $DIRECTORY/bin/magento cache:enable
 php $DIRECTORY/bin/magento cache:disable layout block_html collections full_page
 
 ### Generated PhpStorm XML Schema Validation

--- a/git_import.sh
+++ b/git_import.sh
@@ -116,3 +116,38 @@ fi
 if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
 fi
+
+if [ "$nfs" = "true"]; then
+  echo "START - NFS"
+  if [ "$cache" = "redis"]; then
+    echo "configuring redis"
+    valet redis on
+    $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
+    $PHP $DIRECTORY/bin/magento setup:config:set --page-cache=redis --page-cache-redis-server=127.0.0.1 --page-cache-redis-db=1
+  fi
+  echo "installing mage2tv/magento-cache-clean (can be used as cf --watch - see https://github.com/mage2tv/magento-cache-clean for more information)"
+  $COMPOSER require --dev mage2tv/cache-clean --working-dir=$DIRECTORY
+
+  echo "enabling all caches because mage2tv/magento-cache-clean is now available"
+  $PHP $DIRECTORY/bin/magento cache:enable
+
+  echo "removing ui bookmarks to prevent page size of 100+ in Admin"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "TRUNCATE ui_bookmark;"
+
+  echo "disable admin action logs commerce/enterprise"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'admin/magento_logging/actions', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "cleaning up the var/log folder"
+  rm $DIRECTORY/var/log/*
+
+  echo "set index to schedule"
+  $PHP $DIRECTORY/bin/magento index:set-mode schedule
+
+  echo "disable Experius_ApiLogger"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "disable remote_autostart xdebug"
+  valet xdebug on --remote_autostart=0
+  echo "END - NFS"
+fi

--- a/git_import.sh
+++ b/git_import.sh
@@ -117,7 +117,7 @@ if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
 fi
 
-if [ "$nfs" = "true"]; then
+if [ "$nfs" = "true" ]; then
   echo "START - NFS"
   if [ "$cache" = "redis"]; then
     echo "configuring redis"

--- a/import.sh
+++ b/import.sh
@@ -85,9 +85,9 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'emailcatcher/general/smtp_disable', '1') ON DUPLICATE KEY UPDATE value='1';"
 
 ## Remove the import files
-rm $DIRECTORY/files.tar.gz
-rm $DIRECTORY/structure.sql
-rm $DIRECTORY/data.sql
+#rm $DIRECTORY/files.tar.gz
+#rm $DIRECTORY/structure.sql
+#rm $DIRECTORY/data.sql
 
 ## Delete Current Admin User and Create New Admin User
 $MAGERUN_COMMAND --root-dir=$DIRECTORY admin:user:delete $MAGENTO_USERNAME -f
@@ -102,7 +102,7 @@ if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
 fi
 
-if [ "$nfs" = "true"]; then
+if [ "$nfs" = "true" ]; then
   echo "START - NFS"
   if [ "$cache" = "redis"]; then
     echo "configuring redis"

--- a/import.sh
+++ b/import.sh
@@ -101,3 +101,38 @@ fi
 if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
 fi
+
+if [ "$nfs" = "true"]; then
+  echo "START - NFS"
+  if [ "$cache" = "redis"]; then
+    echo "configuring redis"
+    valet redis on
+    $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
+    $PHP $DIRECTORY/bin/magento setup:config:set --page-cache=redis --page-cache-redis-server=127.0.0.1 --page-cache-redis-db=1
+  fi
+  echo "installing mage2tv/magento-cache-clean (can be used as cf --watch - see https://github.com/mage2tv/magento-cache-clean for more information)"
+  $COMPOSER require --dev mage2tv/cache-clean --working-dir=$DIRECTORY
+
+  echo "enabling all caches because mage2tv/magento-cache-clean is now available"
+  $PHP $DIRECTORY/bin/magento cache:enable
+
+  echo "removing ui bookmarks to prevent page size of 100+ in Admin"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "TRUNCATE ui_bookmark;"
+
+  echo "disable admin action logs commerce/enterprise"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'admin/magento_logging/actions', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "cleaning up the var/log folder"
+  rm $DIRECTORY/var/log/*
+
+  echo "set index to schedule"
+  $PHP $DIRECTORY/bin/magento index:set-mode schedule
+
+  echo "disable Experius_ApiLogger"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "disable remote_autostart xdebug"
+  valet xdebug on --remote_autostart=0
+  echo "END - NFS"
+fi

--- a/import.sh
+++ b/import.sh
@@ -85,9 +85,9 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'emailcatcher/general/smtp_disable', '1') ON DUPLICATE KEY UPDATE value='1';"
 
 ## Remove the import files
-#rm $DIRECTORY/files.tar.gz
-#rm $DIRECTORY/structure.sql
-#rm $DIRECTORY/data.sql
+rm $DIRECTORY/files.tar.gz
+rm $DIRECTORY/structure.sql
+rm $DIRECTORY/data.sql
 
 ## Delete Current Admin User and Create New Admin User
 $MAGERUN_COMMAND --root-dir=$DIRECTORY admin:user:delete $MAGENTO_USERNAME -f

--- a/import.sh
+++ b/import.sh
@@ -43,8 +43,8 @@ if [ -f "$DIRECTORY/app/etc/env.php" ]; then
         MAGERUN_COMMAND=$MAGERUN2_COMMAND
 else
 		VERSION="m1"
-		MAGERUN_COMMAND=$MAGERUN1_COMMAND        
-fi 
+		MAGERUN_COMMAND=$MAGERUN1_COMMAND
+fi
 
 if [ "$VERSION" = "m2" ]; then
 	## Create new env.php
@@ -65,6 +65,7 @@ done
 
 ## Developer Settings
 php $DIRECTORY/bin/magento deploy:mode:set developer
+$PHP $DIRECTORY/bin/magento cache:enable
 php $DIRECTORY/bin/magento cache:disable layout block_html collections full_page
 
 ### Generated PhpStorm XML Schema Validation

--- a/import.sh
+++ b/import.sh
@@ -104,7 +104,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis"]; then
+  if [ "$cache" = "redis" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0

--- a/init_cloud.sh
+++ b/init_cloud.sh
@@ -105,7 +105,7 @@ if [ "$secure" = "true" ]; then
 	valet secure $VALET_DOMAIN
 fi
 
-if [ "$nfs" = "true"]; then
+if [ "$nfs" = "true" ]; then
   echo "START - NFS"
   if [ "$cache" = "redis"]; then
     echo "configuring redis"

--- a/init_cloud.sh
+++ b/init_cloud.sh
@@ -107,7 +107,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis"]; then
+  if [ "$cache" = "redis" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0

--- a/init_cloud.sh
+++ b/init_cloud.sh
@@ -84,6 +84,7 @@ $PHP $DIRECTORY/bin/magento setup:upgrade
 
 ## Developer Settings
 $PHP $DIRECTORY/bin/magento deploy:mode:set developer
+$PHP $DIRECTORY/bin/magento cache:enable
 $PHP $DIRECTORY/bin/magento cache:disable layout block_html collections full_page
 ### Generated PhpStorm XML Schema Validation
 mkdir -p $DIRECTORY/.idea
@@ -99,7 +100,7 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'system/smtp/disable', '1') ON DUPLICATE KEY UPDATE value='1';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'emailcatcher/general/enabled', '1') ON DUPLICATE KEY UPDATE value='1';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'emailcatcher/general/smtp_disable', '1') ON DUPLICATE KEY UPDATE value='1';"
-
+mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'dev/css/minify_files', '0') ON DUPLICATE KEY UPDATE value='0';"
 if [ "$secure" = "true" ]; then
 	valet secure $VALET_DOMAIN
 fi

--- a/init_cloud.sh
+++ b/init_cloud.sh
@@ -105,6 +105,41 @@ if [ "$secure" = "true" ]; then
 	valet secure $VALET_DOMAIN
 fi
 
+if [ "$nfs" = "true"]; then
+  echo "START - NFS"
+  if [ "$cache" = "redis"]; then
+    echo "configuring redis"
+    valet redis on
+    $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
+    $PHP $DIRECTORY/bin/magento setup:config:set --page-cache=redis --page-cache-redis-server=127.0.0.1 --page-cache-redis-db=1
+  fi
+  echo "installing mage2tv/magento-cache-clean (can be used as cf --watch - see https://github.com/mage2tv/magento-cache-clean for more information)"
+  $COMPOSER require --dev mage2tv/cache-clean --working-dir=$DIRECTORY
+
+  echo "enabling all caches because mage2tv/magento-cache-clean is now available"
+  $PHP $DIRECTORY/bin/magento cache:enable
+
+  echo "removing ui bookmarks to prevent page size of 100+ in Admin"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "TRUNCATE ui_bookmark;"
+
+  echo "disable admin action logs commerce/enterprise"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'admin/magento_logging/actions', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "cleaning up the var/log folder"
+  rm $DIRECTORY/var/log/*
+
+  echo "set index to schedule"
+  $PHP $DIRECTORY/bin/magento index:set-mode schedule
+
+  echo "disable Experius_ApiLogger"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "disable remote_autostart xdebug"
+  valet xdebug on --remote_autostart=0
+  echo "END - NFS"
+fi
+
 
 # Bitbucket START
 echo Fill in the bitbucket repository name like teamname/reponame

--- a/install.sh
+++ b/install.sh
@@ -134,3 +134,39 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 if [ "$secure" = "true" ]; then
 	valet secure $VALET_DOMAIN
 fi
+
+
+if [ "$nfs" = "true"]; then
+  echo "START - NFS"
+  if [ "$cache" = "redis"]; then
+    echo "configuring redis"
+    valet redis on
+    $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
+    $PHP $DIRECTORY/bin/magento setup:config:set --page-cache=redis --page-cache-redis-server=127.0.0.1 --page-cache-redis-db=1
+  fi
+  echo "installing mage2tv/magento-cache-clean (can be used as cf --watch - see https://github.com/mage2tv/magento-cache-clean for more information)"
+  $COMPOSER require --dev mage2tv/cache-clean --working-dir=$DIRECTORY
+
+  echo "enabling all caches because mage2tv/magento-cache-clean is now available"
+  $PHP $DIRECTORY/bin/magento cache:enable
+
+  echo "removing ui bookmarks to prevent page size of 100+ in Admin"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "TRUNCATE ui_bookmark;"
+
+  echo "disable admin action logs commerce/enterprise"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'admin/magento_logging/actions', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "cleaning up the var/log folder"
+  rm $DIRECTORY/var/log/*
+
+  echo "set index to schedule"
+  $PHP $DIRECTORY/bin/magento index:set-mode schedule
+
+  echo "disable Experius_ApiLogger"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "disable remote_autostart xdebug"
+  valet xdebug on --remote_autostart=0
+  echo "END - NFS"
+fi

--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ if [ "$secure" = "true" ]; then
 fi
 
 
-if [ "$nfs" = "true"]; then
+if [ "$nfs" = "true" ]; then
   echo "START - NFS"
   if [ "$cache" = "redis"]; then
     echo "configuring redis"

--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis"]; then
+  if [ "$cache" = "redis" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0

--- a/install.sh
+++ b/install.sh
@@ -40,8 +40,8 @@ if [[ $EDITION != "custom-"* ]]; then
     fi
     ## Create Webshop Directory
     mkdir $DIRECTORY
-fi 
-## Create Database	
+fi
+## Create Database
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -e "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE_NAME\`"
 
 COMPOSER="composer"
@@ -87,7 +87,7 @@ else
 	$COMPOSER create-project --repository-url=https://repo.magento.com/ $V $DIRECTORY $OPTIONS
 fi
 
-## Install Sample Data 
+## Install Sample Data
 mkdir $DIRECTORY/var/composer_home
 
 ## Copy Json Auth
@@ -100,19 +100,20 @@ mkdir $DIRECTORY/app/code
 mkdir $DIRECTORY/app/code/$MAGENTO_MODULE_VENDOR
 
 ## Sample Data Deploy
-$PHP $DIRECTORY/bin/magento sampledata:deploy 
+$PHP $DIRECTORY/bin/magento sampledata:deploy
 
 ## Install Magento
 URL="http://$DOMAIN"
 if [ "$secure" = "true" ]; then
 	URL="https://$DOMAIN"
 fi
-$PHP $DIRECTORY/bin/magento setup:install --admin-firstname="$MAGENTO_USERNAME" --admin-lastname="$MAGENTO_USERNAME" --admin-email="$MAGENTO_USER_EMAIL" --admin-user="$MAGENTO_USERNAME" --admin-password="$MAGENTO_PASSWORD" --base-url="$URL" --backend-frontname="$MAGENTO_ADMIN_URL" --db-host="localhost" --db-name="$MYSQL_DATABASE_NAME" --db-user="$MYSQL_USER" --db-password="$MYSQL_PASSWORD" --language=nl_NL --currency=EUR --timezone=Europe/Amsterdam --use-rewrites=1 --session-save=files --use-sample-data 	
+$PHP $DIRECTORY/bin/magento setup:install --admin-firstname="$MAGENTO_USERNAME" --admin-lastname="$MAGENTO_USERNAME" --admin-email="$MAGENTO_USER_EMAIL" --admin-user="$MAGENTO_USERNAME" --admin-password="$MAGENTO_PASSWORD" --base-url="$URL" --backend-frontname="$MAGENTO_ADMIN_URL" --db-host="localhost" --db-name="$MYSQL_DATABASE_NAME" --db-user="$MYSQL_USER" --db-password="$MYSQL_PASSWORD" --language=nl_NL --currency=EUR --timezone=Europe/Amsterdam --use-rewrites=1 --session-save=files --use-sample-data
 
 $PHP $DIRECTORY/bin/magento setup:upgrade
 
 ## Developer Settings
 $PHP $DIRECTORY/bin/magento deploy:mode:set developer
+$PHP $DIRECTORY/bin/magento cache:enable
 $PHP $DIRECTORY/bin/magento cache:disable layout block_html collections full_page
 ### Generated PhpStorm XML Schema Validation
 mkdir -p $DIRECTORY/.idea
@@ -122,6 +123,7 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'web/cookie/cookie_lifetime', '31536000') ON DUPLICATE KEY UPDATE value='31536000';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'dev/static/sign', '0') ON DUPLICATE KEY UPDATE value='0';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'dev/css/merge_css_files', '0') ON DUPLICATE KEY UPDATE value='0';"
+mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'dev/css/minify_files', '0') ON DUPLICATE KEY UPDATE value='0';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'dev/js/merge_files', '0') ON DUPLICATE KEY UPDATE value='0';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'dev/js/minify_files', '0') ON DUPLICATE KEY UPDATE value='0';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'dev/js/enable_js_bundling', '0') ON DUPLICATE KEY UPDATE value='0';"

--- a/install_pr.sh
+++ b/install_pr.sh
@@ -65,6 +65,7 @@ else
 fi
 git remote add fork $FORKED_REPO
 $COMPOSER install -d $DIRECTORY
+rm $DIRECTORY/var/.regenerate
 
 ## Install Sample Data
 mkdir $DIRECTORY/var/composer_home
@@ -88,6 +89,7 @@ $PHP $DIRECTORY/bin/magento setup:upgrade
 
 ## Developer Settings
 $PHP $DIRECTORY/bin/magento deploy:mode:set developer
+$PHP $DIRECTORY/bin/magento cache:enable
 $PHP $DIRECTORY/bin/magento cache:disable layout block_html collections full_page
 ### Generated PhpStorm XML Schema Validation
 mkdir -p $DIRECTORY/.idea
@@ -103,7 +105,7 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'system/smtp/disable', '1') ON DUPLICATE KEY UPDATE value='1';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'emailcatcher/general/enabled', '1') ON DUPLICATE KEY UPDATE value='1';"
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'emailcatcher/general/smtp_disable', '1') ON DUPLICATE KEY UPDATE value='1';"
-
+mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'dev/css/minify_files', '0') ON DUPLICATE KEY UPDATE value='0';"
 if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
 fi

--- a/install_pr.sh
+++ b/install_pr.sh
@@ -110,7 +110,7 @@ if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
 fi
 
-if [ "$nfs" = "true"]; then
+if [ "$nfs" = "true" ]; then
   echo "START - NFS"
   if [ "$cache" = "redis"]; then
     echo "configuring redis"

--- a/install_pr.sh
+++ b/install_pr.sh
@@ -112,7 +112,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis"]; then
+  if [ "$cache" = "redis" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0

--- a/install_pr.sh
+++ b/install_pr.sh
@@ -109,3 +109,38 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
 fi
+
+if [ "$nfs" = "true"]; then
+  echo "START - NFS"
+  if [ "$cache" = "redis"]; then
+    echo "configuring redis"
+    valet redis on
+    $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
+    $PHP $DIRECTORY/bin/magento setup:config:set --page-cache=redis --page-cache-redis-server=127.0.0.1 --page-cache-redis-db=1
+  fi
+  echo "installing mage2tv/magento-cache-clean (can be used as cf --watch - see https://github.com/mage2tv/magento-cache-clean for more information)"
+  $COMPOSER require --dev mage2tv/cache-clean --working-dir=$DIRECTORY
+
+  echo "enabling all caches because mage2tv/magento-cache-clean is now available"
+  $PHP $DIRECTORY/bin/magento cache:enable
+
+  echo "removing ui bookmarks to prevent page size of 100+ in Admin"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "TRUNCATE ui_bookmark;"
+
+  echo "disable admin action logs commerce/enterprise"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'admin/magento_logging/actions', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "cleaning up the var/log folder"
+  rm $DIRECTORY/var/log/*
+
+  echo "set index to schedule"
+  $PHP $DIRECTORY/bin/magento index:set-mode schedule
+
+  echo "disable Experius_ApiLogger"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "disable remote_autostart xdebug"
+  valet xdebug on --remote_autostart=0
+  echo "END - NFS"
+fi

--- a/update.sh
+++ b/update.sh
@@ -41,8 +41,8 @@ if [ -f "$DIRECTORY/app/etc/env.php" ]; then
         MAGERUN_COMMAND=$MAGERUN2_COMMAND
 else
 	VERSION="m1"
-	MAGERUN_COMMAND=$MAGERUN1_COMMAND        
-fi 
+	MAGERUN_COMMAND=$MAGERUN1_COMMAND
+fi
 
 if [ "$VERSION" = "m2" ]; then
 	## Create new env.php
@@ -88,4 +88,39 @@ fi
 
 if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
+fi
+
+if [ "$nfs" = "true"]; then
+  echo "START - NFS"
+  if [ "$cache" = "redis"]; then
+    echo "configuring redis"
+    valet redis on
+    $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
+    $PHP $DIRECTORY/bin/magento setup:config:set --page-cache=redis --page-cache-redis-server=127.0.0.1 --page-cache-redis-db=1
+  fi
+  echo "installing mage2tv/magento-cache-clean (can be used as cf --watch - see https://github.com/mage2tv/magento-cache-clean for more information)"
+  $COMPOSER require --dev mage2tv/cache-clean --working-dir=$DIRECTORY
+
+  echo "enabling all caches because mage2tv/magento-cache-clean is now available"
+  $PHP $DIRECTORY/bin/magento cache:enable
+
+  echo "removing ui bookmarks to prevent page size of 100+ in Admin"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "TRUNCATE ui_bookmark;"
+
+  echo "disable admin action logs commerce/enterprise"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'admin/magento_logging/actions', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "cleaning up the var/log folder"
+  rm $DIRECTORY/var/log/*
+
+  echo "set index to schedule"
+  $PHP $DIRECTORY/bin/magento index:set-mode schedule
+
+  echo "disable Experius_ApiLogger"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
+  mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
+
+  echo "disable remote_autostart xdebug"
+  valet xdebug on --remote_autostart=0
+  echo "END - NFS"
 fi

--- a/update.sh
+++ b/update.sh
@@ -74,8 +74,8 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'emailcatcher/general/smtp_disable', '1') ON DUPLICATE KEY UPDATE value='1';"
 
 ## Remove the import files
-#rm $DIRECTORY/structure.sql
-#rm $DIRECTORY/data.sql
+rm $DIRECTORY/structure.sql
+rm $DIRECTORY/data.sql
 
 ## Delete Current Admin User and Create New Admin User
 $MAGERUN_COMMAND --root-dir=$DIRECTORY admin:user:delete $MAGENTO_USERNAME -f

--- a/update.sh
+++ b/update.sh
@@ -74,8 +74,8 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'emailcatcher/general/smtp_disable', '1') ON DUPLICATE KEY UPDATE value='1';"
 
 ## Remove the import files
-rm $DIRECTORY/structure.sql
-rm $DIRECTORY/data.sql
+#rm $DIRECTORY/structure.sql
+#rm $DIRECTORY/data.sql
 
 ## Delete Current Admin User and Create New Admin User
 $MAGERUN_COMMAND --root-dir=$DIRECTORY admin:user:delete $MAGENTO_USERNAME -f
@@ -90,7 +90,7 @@ if [ "$secure" = "true" ]; then
         valet secure $VALET_DOMAIN
 fi
 
-if [ "$nfs" = "true"]; then
+if [ "$nfs" = "true" ]; then
   echo "START - NFS"
   if [ "$cache" = "redis"]; then
     echo "configuring redis"

--- a/update.sh
+++ b/update.sh
@@ -92,7 +92,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis"]; then
+  if [ "$cache" = "redis" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0


### PR DESCRIPTION
fast localbox

- check if caching is enabled (nano app/etc/env.php because if you use php bin/magento cache:list but that will take a long time)
- Magento Cache Clean from mage2tv
    - https://github.com/mage2tv/magento-cache-clean 
    - enable all caching
    - cf --watch (equal to vendor/bin/cache-clean.js --watch)
    - STOP USING php bin/magento cache:flush
- valet redis cache (or memcache) (soon I will be experimenting also with varnish)
    - enable https://github.com/weprovide/valet-plus#redis
    - configure https://devdocs.magento.com/guides/v2.3/config-guide/redis/redis-pg-cache.html#results
- valet xdebug remote autostart 0
    - https://github.com/weprovide/valet-plus#xdebug
    - using postman > add param ?XDEBUG_SESSION_START=PHPSTORM
- Indexing on Schedule
    -  php bin/magento index:set-mode schedule
- disable minify, merge js, html and css
    - this done by https://github.com/experius/Magento-2-Bash-Localhost-Installation-Script/blob/master/import.sh#L74 
- use php bin/magento setup:upgrade with the keep-generated paramater when you only need to run
- disable server side less compile
    - dev/front_end_development_workflow/type > server_side_compilation
- clean up your var/log folder sometimes because if the file is very large the writing process is slower
- disable api logger on localbox by default 
- only use template hints when necessary based on param
- remove bookmarks from the ui_bookmarks table to prevent page size of 100+ in admin grids
- disable the admin action logs of enterprise