### PR TITLE
Added valet config variable to prevent valet-plus commands from being run

### DIFF
--- a/config.sample.sh
+++ b/config.sample.sh
@@ -52,3 +52,4 @@ GIT_REPO_VENDOR='example'
 nfs="true"
 cache="redis"
 xdebug="true"
+valet="linux"

--- a/git_import.sh
+++ b/git_import.sh
@@ -119,7 +119,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis" ]; then
+  if [ "$cache" = "redis" ] && [ "$valet" = "plus" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
@@ -147,7 +147,7 @@ if [ "$nfs" = "true" ]; then
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
 
-  if [ "$xdebug" = "true" ]; then
+  if [ "$xdebug" = "true" ] && [ "$valet" = "plus" ]; then
     echo "disable remote_autostart xdebug"
     valet xdebug on --remote_autostart=0
   fi

--- a/import.sh
+++ b/import.sh
@@ -104,7 +104,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis" ]; then
+  if [ "$cache" = "redis" ] && [ "$valet" = "plus" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
@@ -132,7 +132,7 @@ if [ "$nfs" = "true" ]; then
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
 
-  if [ "$xdebug" = "true" ]; then
+  if [ "$xdebug" = "true" ] && [ "$valet" = "plus" ]; then
     echo "disable remote_autostart xdebug"
     valet xdebug on --remote_autostart=0
   fi

--- a/init_cloud.sh
+++ b/init_cloud.sh
@@ -107,7 +107,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis" ]; then
+  if [ "$cache" = "redis" ] && [ "$valet" = "plus" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
@@ -135,7 +135,7 @@ if [ "$nfs" = "true" ]; then
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
 
-  if [ "$xdebug" = "true" ]; then
+  if [ "$xdebug" = "true" ] && [ "$valet" = "plus" ]; then
     echo "disable remote_autostart xdebug"
     valet xdebug on --remote_autostart=0
   fi

--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis" ]; then
+  if [ "$cache" = "redis" ] && [ "$valet" = "plus" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
@@ -166,7 +166,7 @@ if [ "$nfs" = "true" ]; then
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
 
-  if [ "$xdebug" = "true" ]; then
+  if [ "$xdebug" = "true" ] && [ "$valet" = "plus" ]; then
     echo "disable remote_autostart xdebug"
     valet xdebug on --remote_autostart=0
   fi

--- a/install_pr.sh
+++ b/install_pr.sh
@@ -112,7 +112,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis" ]; then
+  if [ "$cache" = "redis" ] && [ "$valet" = "plus" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
@@ -140,7 +140,7 @@ if [ "$nfs" = "true" ]; then
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
 
-  if [ "$xdebug" = "true" ]; then
+  if [ "$xdebug" = "true" ] && [ "$valet" = "plus" ]; then
     echo "disable remote_autostart xdebug"
     valet xdebug on --remote_autostart=0
   fi

--- a/update.sh
+++ b/update.sh
@@ -92,7 +92,7 @@ fi
 
 if [ "$nfs" = "true" ]; then
   echo "START - NFS"
-  if [ "$cache" = "redis" ]; then
+  if [ "$cache" = "redis" ] && [ "$valet" = "plus" ]; then
     echo "configuring redis"
     valet redis on
     $PHP $DIRECTORY/bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0
@@ -120,7 +120,7 @@ if [ "$nfs" = "true" ]; then
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_rest', '0') ON DUPLICATE KEY UPDATE value='0';"
   mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "INSERT INTO \`core_config_data\` (\`scope\`, \`scope_id\`, \`path\`, \`value\`) VALUES ('default', 0, 'experius_api_logger/general/enabled_soap', '0') ON DUPLICATE KEY UPDATE value='0';"
 
-  if [ "$xdebug" = "true" ]; then
+  if [ "$xdebug" = "true" ] && [ "$valet" = "plus" ]; then
     echo "disable remote_autostart xdebug"
     valet xdebug on --remote_autostart=0
   fi


### PR DESCRIPTION
Currently ideas are in the works to expand the experius/valet-linux fork to include commands that are available to valet-plus. After which these changes can be expanded upon.

https://github.com/experius/Magento-2-Bash-Localhost-Installation-Script/issues/22