### PR TITLE
Rebuild composer autoload files without the --optimize setting

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -80,6 +80,10 @@ do
 	mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE_NAME -e "UPDATE \`core_config_data\` SET \`value\` ='$URL$STRIPT$DOMAIN_SUFFIX/' WHERE config_id = $config_id"
 	echo "updated url for $STRIPT"
 done
+
+## Dump composer autoload without optimize setting
+cd $DIRECTORY; composer dump-autoload
+
 ## Developer Settings
 php $DIRECTORY/bin/magento deploy:mode:set developer
 $PHP $DIRECTORY/bin/magento cache:enable


### PR DESCRIPTION
When an imported website uses the `composer dump-autoload -o --apcu` setting some classes can't be loaded after importing the website. Triggering a new dump of the autoload configuration (before classes will be compiled by the `bin/magento deploy:mode:set developer` command)will solve this issue.